### PR TITLE
Allow judge without additional configuration

### DIFF
--- a/Classes/Processor/Court.php
+++ b/Classes/Processor/Court.php
@@ -156,7 +156,7 @@ class Court implements ProcessorInterface, LoggerAwareInterface
         $fact = (isset($configuration['fact']) && isset($this->facts[$configuration['fact']])) ? $this->facts[$configuration['fact']] : new StaticFactProvider();
 
         if ($fact instanceof AbstractFactProvider) {
-            $judge = $judge->withConfiguration($this->configuration['judges'][$key . '.'])->adjudicate($fact, (int)$key);
+            $judge = $judge->withConfiguration($this->configuration['judges'][$key . '.'] ?? [])->adjudicate($fact, (int)$key);
 
             if ($judge->hasDecision() && !isset($decisions[$judge->getDecision()->getPriority()])) {
                 $decision = $judge->getDecision();


### PR DESCRIPTION
A judge can be configured without additional configuration. Then the additional array-hierarchy is simply null/unset. 

Resolves: #45