### PR TITLE
Update LanguageRedirectMiddleware.php

### DIFF
--- a/Classes/Middleware/LanguageRedirectMiddleware.php
+++ b/Classes/Middleware/LanguageRedirectMiddleware.php
@@ -21,19 +21,24 @@ use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use TYPO3\CMS\Core\LinkHandling\LinkService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Configuration\BackendConfigurationManager;
+use TYPO3\CMS\Extbase\Configuration\ConfigurationManager;
+use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 
 final class LanguageRedirectMiddleware implements MiddlewareInterface
 {
     public function __construct(
-        private readonly BackendConfigurationManager $backendConfigurationManager,
         private readonly LinkService $link
     ) {}
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         if (!$this->isErrorPage($request)) {
-            $typoScript = $this->backendConfigurationManager->getTypoScriptSetup();
+            /** @var ConfigurationManager $configurationManager */
+            $configurationManager = GeneralUtility::makeInstance(ConfigurationManager::class);
+            $typoScript = $configurationManager->getConfiguration(
+                ConfigurationManagerInterface::CONFIGURATION_TYPE_FULL_TYPOSCRIPT,
+                'sitepackage'
+            );
 
             if (isset($typoScript['config.']['tx_locate']) && (int)$typoScript['config.']['tx_locate'] === 1) {
                 $locateSetup = $typoScript['config.']['tx_locate.'];

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
   "name": "leuchtfeuer/locate",
   "description": "The users country, preferred language and other facts will be detected. Depending on configurable rules the user can be redirected to other languages or pages. Locate also provides geo blocking for configurable pages in configurable countries.",
-  "version": "12.0.3",
   "keywords": [
     "TYPO3",
     "extension",
@@ -72,8 +71,8 @@
   "scripts": {
     "post-autoload-dump": [
       "TYPO3\\TestingFramework\\Composer\\ExtensionTestEnvironment::prepare",
-      "mkdir -p .Build/packages/",
-      "[ -L .Build/packages/locate ] || ln -snvf ../../../../. .Build/packages/locate"
+      "mkdir -p .Build/public/typo3conf/ext/",
+      "[ -L .Build/public/typo3conf/ext/locate ] || ln -snvf ../../../../. .Build/public/typo3conf/ext/locate"
     ],
     "cs-fix": ".Build/bin/php-cs-fixer fix --config php-cs-fixer.php --using-cache no --show-progress dots -v"
   },

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "leuchtfeuer/locate",
   "description": "The users country, preferred language and other facts will be detected. Depending on configurable rules the user can be redirected to other languages or pages. Locate also provides geo blocking for configurable pages in configurable countries.",
-  "version": "12.0.0",
+  "version": "12.0.3",
   "keywords": [
     "TYPO3",
     "extension",

--- a/composer.json
+++ b/composer.json
@@ -69,6 +69,14 @@
       "typo3/cms-composer-installers": true
     }
   },
+  "scripts": {
+    "post-autoload-dump": [
+      "TYPO3\\TestingFramework\\Composer\\ExtensionTestEnvironment::prepare",
+      "mkdir -p .Build/packages/",
+      "[ -L .Build/packages/locate ] || ln -snvf ../../../../. .Build/packages/locate"
+    ],
+    "cs-fix": ".Build/bin/php-cs-fixer fix --config php-cs-fixer.php --using-cache no --show-progress dots -v"
+  },
   "extra": {
     "typo3/cms": {
       "cms-package-dir": "{$vendor-dir}/typo3/cms",

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
   "name": "leuchtfeuer/locate",
   "description": "The users country, preferred language and other facts will be detected. Depending on configurable rules the user can be redirected to other languages or pages. Locate also provides geo blocking for configurable pages in configurable countries.",
+  "version": "12.0.0",
   "keywords": [
     "TYPO3",
     "extension",

--- a/composer.json
+++ b/composer.json
@@ -69,14 +69,6 @@
       "typo3/cms-composer-installers": true
     }
   },
-  "scripts": {
-    "post-autoload-dump": [
-      "TYPO3\\TestingFramework\\Composer\\ExtensionTestEnvironment::prepare",
-      "mkdir -p .Build/public/typo3conf/ext/",
-      "[ -L .Build/public/typo3conf/ext/locate ] || ln -snvf ../../../../. .Build/public/typo3conf/ext/locate"
-    ],
-    "cs-fix": ".Build/bin/php-cs-fixer fix --config php-cs-fixer.php --using-cache no --show-progress dots -v"
-  },
   "extra": {
     "typo3/cms": {
       "cms-package-dir": "{$vendor-dir}/typo3/cms",


### PR DESCRIPTION
Replace reading frontend typoscript settings with BackendConfigurationManager in LanguageRedirectMiddleware. This PR replaces reading frontend typoscript with ConfigurationManager instad of BackendConfigurationManager

fixes #54 

Regards
Mike