### PR TITLE
[BUGFIX] Fix #76: simplify dependency management for TYPO3 v13

### DIFF
--- a/Classes/Command/UpdateIpDatabaseCommand.php
+++ b/Classes/Command/UpdateIpDatabaseCommand.php
@@ -33,7 +33,7 @@ use TYPO3\CMS\Core\Http\RequestFactory;
  */
 class UpdateIpDatabaseCommand extends Command
 {
-    protected const string DOWNLOAD_LINK = 'https://www.ip2location.com/download/?token=%s&file=%s';
+    protected const DOWNLOAD_LINK = 'https://www.ip2location.com/download/?token=%s&file=%s';
 
     protected SymfonyStyle $io;
 

--- a/Classes/Domain/DTO/Configuration.php
+++ b/Classes/Domain/DTO/Configuration.php
@@ -13,7 +13,7 @@ namespace Leuchtfeuer\Locate\Domain\DTO;
 
 class Configuration
 {
-    public const string OVERRIDE_PARAMETER = 'setLang';
+    public const OVERRIDE_PARAMETER = 'setLang';
     protected bool $dryRun = false;
     protected bool $excludeBots = true;
     protected bool $sessionHandling = true;

--- a/Classes/Domain/Repository/RegionRepository.php
+++ b/Classes/Domain/Repository/RegionRepository.php
@@ -19,7 +19,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class RegionRepository
 {
-    public const int APPLY_WHEN_NO_IP_MATCHES = -1;
+    public const APPLY_WHEN_NO_IP_MATCHES = -1;
 
     /**
      * @return array<null>|array<string, bool>

--- a/Classes/FactProvider/BrowserAcceptedLanguage.php
+++ b/Classes/FactProvider/BrowserAcceptedLanguage.php
@@ -19,7 +19,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class BrowserAcceptedLanguage extends AbstractFactProvider
 {
-    public const string PROVIDER_NAME = 'browseracceptlanguage';
+    public const PROVIDER_NAME = 'browseracceptlanguage';
 
     protected bool $multiple = true;
 

--- a/Classes/FactProvider/IP2Country.php
+++ b/Classes/FactProvider/IP2Country.php
@@ -18,7 +18,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class IP2Country extends AbstractFactProvider
 {
-    public const string PROVIDER_NAME = 'countrybyip';
+    public const PROVIDER_NAME = 'countrybyip';
 
     /**
      * @inheritDoc

--- a/Classes/FactProvider/StaticFactProvider.php
+++ b/Classes/FactProvider/StaticFactProvider.php
@@ -13,7 +13,7 @@ namespace Leuchtfeuer\Locate\FactProvider;
 
 class StaticFactProvider extends AbstractFactProvider
 {
-    public const string PROVIDER_NAME = 'static';
+    public const PROVIDER_NAME = 'static';
 
     public function getBasename(): string
     {

--- a/Classes/Judge/AbstractJudge.php
+++ b/Classes/Judge/AbstractJudge.php
@@ -17,7 +17,7 @@ use Leuchtfeuer\Locate\FactProvider\AbstractFactProvider;
 
 abstract class AbstractJudge
 {
-    public const int DEFAULT_PRIORITY = 999;
+    public const DEFAULT_PRIORITY = 999;
 
     protected ?Decision $decision = null;
 

--- a/Classes/Store/SessionStore.php
+++ b/Classes/Store/SessionStore.php
@@ -13,7 +13,7 @@ namespace Leuchtfeuer\Locate\Store;
 
 class SessionStore
 {
-    public const string SESSION_BASE_NAME = 'tx_locate_';
+    public const SESSION_BASE_NAME = 'tx_locate_';
 
     protected string $sessionBaseName;
 

--- a/Classes/Verdict/Redirect.php
+++ b/Classes/Verdict/Redirect.php
@@ -27,7 +27,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class Redirect extends AbstractVerdict
 {
-    public const string SESSION_KEY = 'language';
+    public const SESSION_KEY = 'language';
 
     private bool $sessionMode = false;
 

--- a/composer.json
+++ b/composer.json
@@ -27,13 +27,12 @@
     }
   ],
   "require": {
-    "php": ">=8.3",
-    "typo3/cms-backend": "^13.4",
+    "typo3/cms-backend": "*",
     "typo3/cms-core": "^13.4",
-    "typo3/cms-extbase": "^13.4",
-    "typo3/cms-frontend": "^13.4",
-    "symfony/console": "^7.1",
-    "doctrine/dbal": "^4.2",
+    "typo3/cms-extbase": "*",
+    "typo3/cms-frontend": "*",
+    "symfony/console": "*",
+    "doctrine/dbal": "*",
     "jaybizzle/crawler-detect": "^1.3",
     "ext-intl": "*",
     "ext-zip": "*"


### PR DESCRIPTION
This change simplifies dependency management in the following way:
- It removes php version requiremenets because it should match TYPO3 version
- For TYPO3 components it only leaves version requirement for the core and sets other requirements to "*". Since they all depend on the core, the correct one will be selected by composer automatically. This makes small diffs in future.
- It sets "*" to other components as well because they should match TYPO3 requirements

Since this is for v13, it does not have to be merged. Please, feel free to reject and keep it for anybody who has the same case as I do: needs php 8.2 for TYPO3 v13. Or you can merge it and also make similar changes in v14 to optimize dependency management. 😄 

Thanks!